### PR TITLE
[CC-49: Bugfix] validator for Australian number

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     implementation 'com.amazonaws:aws-java-sdk-ses:1.12.315'
+    implementation 'com.googlecode.libphonenumber:libphonenumber:8.12.57'
 
     compileOnly 'org.projectlombok:lombok'
 

--- a/src/main/java/com/courtcanva/ccfranchise/annotations/AustralianNumber.java
+++ b/src/main/java/com/courtcanva/ccfranchise/annotations/AustralianNumber.java
@@ -1,0 +1,23 @@
+package com.courtcanva.ccfranchise.annotations;
+
+import com.courtcanva.ccfranchise.validators.AustralianNumberValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Constraint(validatedBy = AustralianNumberValidator.class)
+public @interface AustralianNumber {
+
+    String message() default "This doesn't seems like a valid Australian number.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/com/courtcanva/ccfranchise/dtos/FranchiseePostDto.java
+++ b/src/main/java/com/courtcanva/ccfranchise/dtos/FranchiseePostDto.java
@@ -1,5 +1,6 @@
 package com.courtcanva.ccfranchise.dtos;
 
+import com.courtcanva.ccfranchise.annotations.AustralianNumber;
 import com.courtcanva.ccfranchise.constants.AUState;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,7 +24,7 @@ public class FranchiseePostDto {
     private String legalEntityName;
 
     @NotBlank(message = "Franchisee's contact number is mandatory")
-    @Pattern(regexp = "^0[0-9]{9}|[0-9]{9}$", message = "Incorrect phone number format")
+    @AustralianNumber
     private String contactNumber;
 
     @NotBlank(message = "Franchisee's abn is mandatory")

--- a/src/main/java/com/courtcanva/ccfranchise/dtos/StaffPostDto.java
+++ b/src/main/java/com/courtcanva/ccfranchise/dtos/StaffPostDto.java
@@ -1,5 +1,6 @@
 package com.courtcanva.ccfranchise.dtos;
 
+import com.courtcanva.ccfranchise.annotations.AustralianNumber;
 import com.courtcanva.ccfranchise.constants.AUState;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,7 +31,7 @@ public class StaffPostDto {
     private String email;
 
     @NotBlank(message = "Staff's phone number is mandatory")
-    @Pattern(regexp = "^0[0-9]{9}|[0-9]{9}$", message = "Incorrect phone number format")
+    @AustralianNumber
     private String phoneNumber;
 
     @NotBlank(message = "Staff's residential address is mandatory")

--- a/src/main/java/com/courtcanva/ccfranchise/validators/AustralianNumberValidator.java
+++ b/src/main/java/com/courtcanva/ccfranchise/validators/AustralianNumberValidator.java
@@ -1,0 +1,30 @@
+package com.courtcanva.ccfranchise.validators;
+
+import com.courtcanva.ccfranchise.annotations.AustralianNumber;
+import com.google.i18n.phonenumbers.NumberParseException;
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import com.google.i18n.phonenumbers.Phonenumber;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+@Slf4j
+public class AustralianNumberValidator implements ConstraintValidator<AustralianNumber, String> {
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext ctx) {
+
+        PhoneNumberUtil phoneNumberUtil = PhoneNumberUtil.getInstance();
+
+        try {
+            Phonenumber.PhoneNumber phoneNumber = phoneNumberUtil.parse(value, "AU");
+
+            return phoneNumberUtil.isValidNumberForRegion(phoneNumber, "AU");
+        } catch (NumberParseException ex) {
+            log.error(ex.getMessage());
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
##### Link to Jira ticekt here: https://leonhard.atlassian.net/browse/CC-49

### Acceptance Criteria:

- Below number SHOULD pass validation
  - `+61421234567`
  - `61421234567`
  - `0421234567`
  - `+61 2 1234 5678`
  - `61 3 1234 5678`
  - `07 1234 5678`

- Below number SHOUT NOT pass validation
  - `86 1234 567 8901`
### Descriptions

The backend wasn't validating Australian phone numbers in the correct format, this is a rework of that validation logic.

### Provide screenshots or videos that the function is working.
### Provide screenshots of no warning, error in console.

_// This really is the best I can do without spending too much time on this_

https://user-images.githubusercontent.com/42906455/200120799-d5360763-cb21-495f-bf8b-4d2e1f672792.mp4



### Developer Checklist

- [x] No merge conflict with the main branch, make sure your code is up to date with main.
- [x] Check PR title is aligned with your ticket, (i.e [CC-xx: Feature] Create pull request template).
- [x] Check your app will run without crashes.
- [x] Check if there are hard coded values, note them if there are anything.
- [x] No unnecessary spaces between lines of code.
- [x] Check you are using camelCase && PascalCase correctly.
- [x] Check you named your code properly.
- [x] Remove unused comments.